### PR TITLE
Bugfix: prevent state model from creating an infinite loop

### DIFF
--- a/doc/state-model.md
+++ b/doc/state-model.md
@@ -79,7 +79,7 @@ By default, the mixin has three methods, listed below. You do not need to call t
 
 - `preinitialize` is predefined to call `this.bindStateEvents()` (next method) and do nothing else. By including this predefined `preinitialize`, we ensure that the mixin's special events are automatically activated in the constructor.
 - `bindStateEvents` ensures that the state model's special events will trigger during the lifetime of the model. For this reason, you must be careful not to override the method. The special events are discussed in the next section.
-- `broadcastStateEvents` is an internal event handler that runs during `change` events. It triggers the individual events discussed in the next section.
+- `broadcastStateEvents` is an internal event handler that runs during `change:[attribute]` events. It triggers the individual events discussed in the next section.
 
 ## State model events
 

--- a/src/state-model.js
+++ b/src/state-model.js
@@ -1,5 +1,7 @@
 import _ from 'underscore';
 
+var changedAttribute = /^change:(.*)$/;
+
 /**
  * Methods that turn a `Backbone.Model` into a state model.
  * @mixin
@@ -16,27 +18,27 @@ var StateMixin = {
      * {@link StateMixin.preinitialize}, call this method once in your own
      * constructor, `preinitialize` or `initialize` method. */
     bindStateEvents: function() {
-        this.on('change', this.broadcastStateEvents);
+        this.on('all', this.broadcastStateEvents);
     },
 
     /** Internal method, the heart of the mixin. For every changed attribute,
      * triggers appropriate`'set:'`, `'exit:'`, `'enter:'` and `'unset:'`
      * events. You do not need to call it yourself. Do NOT override. */
-    broadcastStateEvents: function(model, options) {
+    broadcastStateEvents: function(eventName, model, value, options) {
+        var match = eventName.match(changedAttribute);
+        if (!match) return;
         var current = this.attributes,
             previous = this.previousAttributes(),
-            changed = this.changed;
-        for (var attr in changed) {
-            if (attr in previous) {
-                this.trigger('exit:' + attr, this, previous[attr], options);
-            } else {
-                this.trigger('set:' + attr, this, current[attr], options);
-            }
-            if (attr in current) {
-                this.trigger('enter:' + attr, this, current[attr], options);
-            } else {
-                this.trigger('unset:' + attr, this, previous[attr], options);
-            }
+            attr = match[1];
+        if (attr in previous) {
+            this.trigger('exit:' + attr, this, previous[attr], options);
+        } else {
+            this.trigger('set:' + attr, this, value, options);
+        }
+        if (attr in current) {
+            this.trigger('enter:' + attr, this, value, options);
+        } else {
+            this.trigger('unset:' + attr, this, previous[attr], options);
         }
     }
 };

--- a/src/state-model.test.js
+++ b/src/state-model.test.js
@@ -31,7 +31,7 @@ describe('getStateMixin', function() {
             it('binds the event handler', function() {
                 mixin.on = sinon.fake();
                 mixin.bindStateEvents();
-                assert(mixin.on.calledWith('change', mixin.broadcastStateEvents));
+                assert(mixin.on.calledWith('all', mixin.broadcastStateEvents));
             });
         });
 

--- a/src/state-model.test.js
+++ b/src/state-model.test.js
@@ -133,6 +133,24 @@ describe('getStateMixin', function() {
                 assert(watchers['exit:page'].calledBefore(watchers['unset:page']));
                 assert(watchers['set:user'].calledBefore(watchers['enter:user']));
             });
+
+            it('does not cause infinite loops', function() {
+                instance.set('counter', 0);
+                instance.on('enter:extra', function() {
+                    instance.set('counter', instance.get('counter') + 1);
+                });
+                instance.set('extra', 'abc');
+                // In the above lines of code, the `extra` attribute never
+                // changes. Hence, no feedback loop should be possible. However,
+                // in early versions, this is exactly what happened. How?
+                // Because of nested calls to `Backbone.Model#set`. The
+                // outermost call changes the `extra` attribute, so it remains
+                // in the model's `.changed` property during subsequent
+                // iterations of the loops that issues the `change` event. New
+                // iterations keep being added because the `counter` attribute
+                // does change.
+                assert(instance.get('counter') === 1);
+            });
         });
     });
 


### PR DESCRIPTION
While working on the EDPOP VRE, I discovered a bug in the state model mixin that can cause infinite feedback loops in situations where it should not. These changes address that bug.